### PR TITLE
Build option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,13 +7,15 @@ use error::Result;
 pub const APP_NAME: &'static str = "llvmenv";
 pub const ENTRY_TOML: &'static str = "entry.toml";
 
+/// Example of entry.toml
 const DEFAULT_ENTRY: &'static [u8] = br#"
 [llvm-dev]
-llvm_git = "https://github.com/llvm-mirror/llvm"
+llvm_git  = "https://github.com/llvm-mirror/llvm"
 clang_git = "https://github.com/llvm-mirror/clang"
-target   = ["X86"]
-example  = 0
-document = 0
+build     = "Release"
+target    = ["X86"]
+example   = 0
+document  = 0
 "#;
 
 pub fn config_dir() -> PathBuf {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -74,6 +74,10 @@ impl Entry {
         self.prefix = prefix.into();
     }
 
+    pub fn overwrite_build(&mut self, build: &str) {
+        self.build = build.into();
+    }
+
     pub fn get_name(&self) -> &str {
         &self.name
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,8 @@ enum LLVMEnv {
         nproc: Option<usize>,
         #[structopt(long = "prefix", parse(from_os_str), help = "Overwrite prefix")]
         prefix: Option<PathBuf>,
+        #[structopt(long = "build", help = "Overwrite cmake build setting (Debug/Release)")]
+        build: Option<String>,
     },
 
     #[structopt(name = "current", about = "Show the name of current build")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,8 +26,11 @@ use std::process::exit;
 use structopt::StructOpt;
 
 #[derive(StructOpt, Debug)]
-#[structopt(name = "llvmenv", about = "Manage multiple LLVM/Clang builds",
-            raw(setting = "structopt::clap::AppSettings::ColoredHelp"))]
+#[structopt(
+    name = "llvmenv",
+    about = "Manage multiple LLVM/Clang builds",
+    raw(setting = "structopt::clap::AppSettings::ColoredHelp")
+)]
 enum LLVMEnv {
     #[structopt(name = "init", about = "Initialize llvmenv")]
     Init {},

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,6 +107,7 @@ fn main() -> error::Result<()> {
             update,
             nproc,
             prefix,
+            build,
         } => {
             let mut entry = entry::load_entry(&name)?;
             if let Some(prefix) = prefix {
@@ -117,6 +118,9 @@ fn main() -> error::Result<()> {
             entry.checkout().unwrap();
             if update {
                 entry.fetch().unwrap();
+            }
+            if let Some(build) = build {
+                entry.overwrite_build(&build);
             }
             entry.build(nproc).unwrap();
         }


### PR DESCRIPTION
- add `--build` option to `build-entry` subcommand to overwrite the setting by entry.toml
- Add `build = "Release"` in the default entry.toml generated by `llvmenv init`