### PR TITLE
"version" subcommand

### DIFF
--- a/llvmenv.zsh
+++ b/llvmenv.zsh
@@ -13,9 +13,14 @@ function llvmenv_append_path() {
   fi
 }
 
+function llvmenv_env_llvm_sys () {
+  export LLVM_SYS_$(llvmenv version --major --minor)_PREFIX=$(llvmenv prefix)
+}
+
 function llvmenv_update () {
   llvmenv_remove_path
   llvmenv_append_path
+  llvmenv_env_llvm_sys
 }
 
 autoload -Uz add-zsh-hook

--- a/llvmenv.zsh
+++ b/llvmenv.zsh
@@ -20,7 +20,9 @@ function llvmenv_env_llvm_sys () {
 function llvmenv_update () {
   llvmenv_remove_path
   llvmenv_append_path
-  llvmenv_env_llvm_sys
+  if [[ -n "$LLVMENV_RUST_BINDING" ]]; then
+    llvmenv_env_llvm_sys
+  fi
 }
 
 autoload -Uz add-zsh-hook

--- a/src/build.rs
+++ b/src/build.rs
@@ -5,7 +5,6 @@ use glob::glob;
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::str::FromStr;
 use std::{env, fs};
 
 use config::*;
@@ -100,7 +99,11 @@ impl Build {
         let output = ::std::str::from_utf8(&output.stdout)?;
         let v = output
             .split(".")
-            .map(|s| FromStr::from_str(s).map_err(|_| err_msg("Cannot parse version")))
+            .map(|s| {
+                s.trim()
+                    .parse()
+                    .map_err(|_| err_msg(format!("Cannot parse version: {}", s)))
+            })
             .collect::<Result<Vec<_>>>()?;
         if v.len() != 3 {
             return Err(err_msg("Unexpected output from llvm-config"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,17 @@ enum LLVMEnv {
         #[structopt(short = "v", long = "verbose")]
         verbose: bool,
     },
+    #[structopt(name = "version", about = "Show the base version of the current build")]
+    Version {
+        #[structopt(short = "n", long = "name")]
+        name: Option<String>,
+        #[structopt(long = "major")]
+        major: bool,
+        #[structopt(long = "minor")]
+        minor: bool,
+        #[structopt(long = "patch")]
+        patch: bool,
+    },
 
     #[structopt(name = "global", about = "Set the build to use (global)")]
     Global { name: String },
@@ -152,6 +163,33 @@ fn main() -> error::Result<()> {
                 if let Some(env) = build.env_path() {
                     eprintln!("set by {}", env.display());
                 }
+            }
+        }
+        LLVMEnv::Version {
+            name,
+            major,
+            minor,
+            patch,
+        } => {
+            let build = if let Some(name) = name {
+                get_existing_build(&name)
+            } else {
+                build::seek_build()?
+            };
+            let (ma, mi, pa) = build.version()?;
+            if !(major || minor || patch) {
+                println!("{}.{}.{}", ma, mi, pa);
+            } else {
+                if major {
+                    print!("{}", ma);
+                }
+                if minor {
+                    print!("{}", mi);
+                }
+                if patch {
+                    print!("{}", pa);
+                }
+                println!("");
             }
         }
 


### PR DESCRIPTION
Resolve #16 

- use current build if `--name` (or `-n`) is not specified
- export `LLVM_SYS_{VERSION}_PREFIX` automatically for [llvm-sys] rust binding  if `$LLVMENV_RUST_BINDING` is nonzero 

[llvm-sys]: https://github.com/tari/llvm-sys.rs