### PR TITLE
enable using VS2017 Win64 generator and multiconfiguration Release mode

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -91,6 +91,8 @@ pub enum CMakeGenerator {
     Ninja,
     /// Visual Studio 15 2017
     VisualStudio,
+    /// Visual Studio 15 2017 Win64
+    VisualStudioWin64,
 }
 
 impl CMakeGenerator {
@@ -117,15 +119,20 @@ impl CMakeGenerator {
             CMakeGenerator::Makefile => vec!["-G", "Unix Makefiles"],
             CMakeGenerator::Ninja => vec!["-G", "Ninja"],
             CMakeGenerator::VisualStudio => vec!["-G", "Visual Studio 15 2017"],
+            CMakeGenerator::VisualStudioWin64 => vec!["-G", "Visual Studio 15 2017 Win64", "-Thost=x64"],
         }
         .into_iter()
         .map(|s| s.into())
         .collect()
     }
 
-    fn build_option(&self, nproc: usize) -> Vec<String> {
+    fn build_option(&self, nproc: usize, build_type: BuildType) -> Vec<String> {
         match self {
-            CMakeGenerator::VisualStudio | CMakeGenerator::Platform => Vec::new(),
+            CMakeGenerator::VisualStudioWin64|CMakeGenerator::VisualStudio => vec![
+                "--config".into(),
+                format!("{:?}", build_type)
+            ],
+            CMakeGenerator::Platform => Vec::new(),
             CMakeGenerator::Makefile | CMakeGenerator::Ninja => {
                 vec!["--".into(), "-j".into(), format!("{}", nproc)]
             }
@@ -140,7 +147,7 @@ impl Default for CMakeGenerator {
 }
 
 /// CMake build type
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone, Copy)]
 pub enum BuildType {
     Debug,
     Release,
@@ -421,7 +428,9 @@ impl Entry {
                 "--target",
                 "install",
             ])
-            .args(&self.setting().builder.build_option(nproc))
+            .args(&self.setting().builder.build_option(
+                nproc,
+                self.setting().build_type))
             .check_run()?;
         Ok(())
     }


### PR DESCRIPTION
This pull request is the last in a series of pull requests to get llvmenv working for me on Windows 10 x64 (see #59  and #58 for the rest). 

This pull request enables building in Release mode using the Visual Studio 2017 CMake generator. The CMake generator creates a multi configuration project, you have to specify the configuration using `--config` when building the project using the `--build` command. This pull request adds either `--config Debug` or `--config Release` depending on the `build-mode` during the build phase for the `VisualStudio` generator.

Besides this, when using the current `VisualStudio` builder, LLVM is build for i686 instead of my machines x86_64.  This causes strange linker errors when linking with binaries build by rust `x86_64-pc-windows-msvc` (the default on my platform). To fix this, llvmenv should use the `Visual Studio 2017 Win64` generator. This pull request basically adds this generator.

So after my series of pull requests (this one, #59  and #58 ) when adding this to your entry.toml:
```
[release_80]
url = "https://github.com/llvm-mirror/llvm#release_80"
target = ["X86"]
build_type = "Release"
builder = "VisualStudioWin64"
```

and running `llvmenv build-entry release_80` you should be all setup with LLVM 8.0 cloned from git, usable by Rust `x86_64-pc-windows-msvc` on Windows.