### PR TITLE
Fallback to SimpleLogger if TermLogger init fails

### DIFF
--- a/src/bin/llvmenv.rs
+++ b/src/bin/llvmenv.rs
@@ -105,6 +105,10 @@ fn main() -> error::Result<()> {
         ConfigBuilder::new().set_time_to_local(true).build(),
         TerminalMode::Mixed,
     )
+    .or(SimpleLogger::init(
+        LevelFilter::Info,
+        ConfigBuilder::new().set_time_to_local(true).build(),
+    ))
     .unwrap();
 
     let opt = LLVMEnv::from_args();


### PR DESCRIPTION
This fixes logging init when llvmenv is executed in docker