### PR TITLE
add download progress bar

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,20 @@ keywords      = ["env", "llvm", "clang"]
 license       = "MIT"
 readme        = "README.md"
 categories    = []
-
-edition = '2018'
+edition       = "2018"
 
 [dependencies]
+bytes = "0.5"
 dirs = "2.0.2"
 fs_extra = "1.1.0"
+futures = "0.3"
 glob = "0.3.0"
+indicatif = "0.15"
 itertools = "0.9.0"
 log = "0.4.8"
 num_cpus = "1.13.0"
 regex = "1.3.7"
-reqwest = { version = "0.10.4", features = ["blocking"] }
+reqwest = { version = "0.10.4", features = ["blocking", "stream"] }
 serde = "1.0.110"
 serde_derive = "1.0.110"
 shellexpand = "2.0.0"
@@ -30,6 +32,7 @@ structopt = "0.3.14"
 tar = "0.4.26"
 tempfile= "3.1.0"
 thiserror = "1.0.16"
+tokio = "0.2"
 toml = "0.5.6"
 url = "2.1.1"
 which = { version = "3.1.1", default-features = false }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,18 @@ pub enum Error {
     },
 
     #[error(transparent)]
+    IoError {
+        #[from]
+        source: io::Error,
+    },
+
+    #[error(transparent)]
+    ParseIntError {
+        #[from]
+        source: std::num::ParseIntError,
+    },
+
+    #[error(transparent)]
     ReqwestError {
         #[from]
         source: reqwest::Error,


### PR DESCRIPTION
Add file download progress bar. Do we need to display what files are currently being downloaded?

```
16:19:14 [ INFO] Download Tar file: https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/llvm-9.0.1.src.tar.xz
  [00:14:16] [######################################] 31.50MB/31.50MB (0s) [37.66KB/s]
16:33:34 [ INFO] Download Tar file: https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/clang-9.0.1.src.tar.xz
  [00:10:02] [######################################] 12.83MB/12.83MB (0s) [21.79KB/s]
16:43:39 [ INFO] Download Tar file: https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/lld-9.0.1.src.tar.xz
  [00:00:19] [######################################] 1.04MB/1.04MB (0s) [55.24KB/s]
16:44:01 [ INFO] Download Tar file: https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/lldb-9.0.1.src.tar.xz
  [00:05:54] [######################################] 9.38MB/9.38MB (0s) [27.06KB/s]
16:49:58 [ INFO] Download Tar file: https://github.com/llvm/llvm-project/releases/download/llvmorg-9.0.1/clang-tools-extra-9.0.1.src.tar.xz
⠒ [00:00:29] [###################>------------------] 1.06MB/2.07MB (29s) [36.70KB/s]
```