### PR TITLE
Add flang in official entry

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -195,7 +195,7 @@ impl Tool {
         match self.relative_path {
             Some(ref rel_path) => rel_path.to_string(),
             None => match self.name.as_str() {
-                "clang" | "lld" | "lldb" | "polly" => format!("tools/{}", self.name),
+                "clang" | "lld" | "lldb" | "polly" | "flang" => format!("tools/{}", self.name),
                 "clang-tools-extra" => "tools/clang/tools/clang-tools-extra".into(),
                 "compiler-rt" | "libcxx" | "libcxxabi" | "libunwind" | "openmp" => {
                     format!("projects/{}", self.name)
@@ -376,6 +376,12 @@ impl Entry {
             "openmp",
             &format!("{}/openmp-{}.src.tar.xz", base_url, version),
         ));
+        if (major, minor, patch) >= (11, 0, 0) {
+            setting.tools.push(Tool::new(
+                "flang",
+                &format!("{}/flang-{}.src.tar.xz", base_url, version),
+            ));
+        }
         Entry::parse_setting(&version, setting).unwrap()
     }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -269,6 +269,8 @@ fn load_entry_toml(toml_str: &str) -> Result<Vec<Entry>> {
 
 pub fn official_releases() -> Vec<Entry> {
     vec![
+        Entry::official(11, 0, 0),
+        Entry::official(10, 0, 1),
         Entry::official(10, 0, 0),
         Entry::official(9, 0, 1),
         Entry::official(8, 0, 1),
@@ -613,6 +615,8 @@ mod tests {
         };
     }
 
+    checkout!(11, 0, 0);
+    checkout!(10, 0, 1);
     checkout!(10, 0, 0);
     checkout!(9, 0, 1);
     checkout!(8, 0, 1);


### PR DESCRIPTION
https://releases.llvm.org/download.html#11.0.0 does not distribute MLIR though flang depends on it.